### PR TITLE
Populate projects page with data from the database

### DIFF
--- a/database/seed.js
+++ b/database/seed.js
@@ -5,19 +5,41 @@ import { config } from '@dotenvx/dotenvx'
 config()
 
 const supabase = createClient(process.env.VITE_SUPABASE_URL, process.env.SERVICE_ROLE_KEY)
+
+const logErrorAndExit = (tableName, error) => {
+  console.error(
+    `An error occurred in table '${tableName} with code ${error.code}: ${error.message}`
+  )
+  process.exit(1)
+}
+
+const logStep = (stepMessage) => {
+  console.log(stepMessage)
+}
+
 const seedProjects = async (numOfEntries) => {
-  const arrayOfInserts = []
+  logStep('Seeding projects...')
+  const projects = []
+
   for (let i = 0; i < numOfEntries; i++) {
     const name = faker.lorem.words(3)
-    const projectObject = {
+    projects.push({
       name,
       slug: name.toLocaleLowerCase().replace(/ /g, '-'),
       status: faker.helpers.arrayElement(['in-progress', 'completed']),
       collaborators: faker.helpers.arrayElements([1, 2, 3])
-    }
-    arrayOfInserts.push(projectObject)
+    })
   }
-  await supabase.from('projects').insert(arrayOfInserts)
+  const { data, error } = await supabase.from('projects').insert(projects).select('id')
+  if (error) return logErrorAndExit('Projects', error)
+  logStep('Projects seeded successfully.')
+  return data
 }
 
-await seedProjects(10)
+const seedDatabase = async (numOfEntriesPerTable) => {
+  await seedProjects(numOfEntriesPerTable)
+}
+
+const numOfEntriesPerTable = 11
+
+seedDatabase(numOfEntriesPerTable)

--- a/database/types.ts
+++ b/database/types.ts
@@ -1,0 +1,135 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
+
+export type Database = {
+  public: {
+    Tables: {
+      projects: {
+        Row: {
+          collaborators: string[]
+          created_at: string
+          id: number
+          name: string
+          slug: string
+          status: Database["public"]["Enums"]["current_status"]
+        }
+        Insert: {
+          collaborators?: string[]
+          created_at?: string
+          id?: never
+          name: string
+          slug: string
+          status?: Database["public"]["Enums"]["current_status"]
+        }
+        Update: {
+          collaborators?: string[]
+          created_at?: string
+          id?: never
+          name?: string
+          slug?: string
+          status?: Database["public"]["Enums"]["current_status"]
+        }
+        Relationships: []
+      }
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      [_ in never]: never
+    }
+    Enums: {
+      current_status: "in-progress" | "completed"
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+}
+
+type PublicSchema = Database[Extract<keyof Database, "public">]
+
+export type Tables<
+  PublicTableNameOrOptions extends
+    | keyof (PublicSchema["Tables"] & PublicSchema["Views"])
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
+        Database[PublicTableNameOrOptions["schema"]]["Views"])
+    : never = never,
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
+      Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] &
+        PublicSchema["Views"])
+    ? (PublicSchema["Tables"] &
+        PublicSchema["Views"])[PublicTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
+    : never
+
+export type TablesInsert<
+  PublicTableNameOrOptions extends
+    | keyof PublicSchema["Tables"]
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
+    : never
+
+export type TablesUpdate<
+  PublicTableNameOrOptions extends
+    | keyof PublicSchema["Tables"]
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
+    : never
+
+export type Enums<
+  PublicEnumNameOrOptions extends
+    | keyof PublicSchema["Enums"]
+    | { schema: keyof Database },
+  EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = PublicEnumNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
+    ? PublicSchema["Enums"][PublicEnumNameOrOptions]
+    : never

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "supabase:link": "supabase link --project-ref ${import.meta.env.VITE_SUPABASE_PROJECT_REF}",
     "db:migrate:new": "supabase migration new projects-schema",
     "db:reset": "supabase db reset --linked",
-    "db:seed": "node database/seed.js"
+    "db:seed": "node database/seed.js",
+    "supabase:types": "npx supabase gen types typescript --project-id ${import.meta.env.VITE_SUPABASE_PROJECT_REF} --schema public > database/types.ts"
   },
   "dependencies": {
     "@dotenvx/dotenvx": "^0.45.0",

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,6 +1,7 @@
 import { createClient } from '@supabase/supabase-js'
+import type { Database } from '../../database/types'
 
-export const supabase = createClient(
+export const supabase = createClient<Database>(
   import.meta.env.VITE_SUPABASE_URL,
   import.meta.env.VITE_SUPABASE_KEY
 )

--- a/src/pages/projects/index.vue
+++ b/src/pages/projects/index.vue
@@ -1,7 +1,23 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { ref } from 'vue'
+import { supabase } from '@/lib/supabaseClient'
+
+const projects = ref()
+
+;(async () => {
+  const { data, error } = await supabase.from('projects').select()
+
+  if (error) {
+    console.error(error)
+  }
+
+  projects.value = data
+})()
+</script>
 <template>
   <div>
     <h1>Projects page</h1>
+    <p>{{ projects.length }} projects</p>
     <RouterLink to="/">Home</RouterLink>
   </div>
 </template>

--- a/src/pages/projects/index.vue
+++ b/src/pages/projects/index.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { supabase } from '@/lib/supabaseClient'
+import type { Tables } from '../../../database/types'
+import { RouterLink } from 'vue-router'
 
-const projects = ref()
+const projects = ref<Tables<'projects'>[] | null>(null)
 
 ;(async () => {
   const { data, error } = await supabase.from('projects').select()
@@ -17,7 +19,9 @@ const projects = ref()
 <template>
   <div>
     <h1>Projects page</h1>
-    <p>{{ projects.length }} projects</p>
-    <RouterLink to="/">Home</RouterLink>
+    <RouterLink to="/">Go to home</RouterLink>
+    <ul>
+      <li v-for="project in projects" :key="project.id">{{ project.name }}</li>
+    </ul>
   </div>
 </template>

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,6 +1,6 @@
 {
   "extends": "@vue/tsconfig/tsconfig.dom.json",
-  "include": ["env.d.ts", "src/**/*", "src/**/*.vue", "typed-router.d.ts"],
+  "include": ["env.d.ts", "src/**/*", "src/**/*.vue", "typed-router.d.ts", "database/types.ts"],
   "exclude": ["src/**/__tests__/*"],
   "compilerOptions": {
     "composite": true,


### PR DESCRIPTION
- Fetch the project data from supabase in the setup with an async IIFE and store in a reactive constant
- Generate types for the supabase d/b and the projects table 
- Add a script to be able to generate types easily as the project evolves
- Use these types in the supabaseClient and in the projects index page
- Include the types in the tsconfig.app.json file to ensure vscode support
