### PR TITLE
Handle errors gracefully

### DIFF
--- a/auto-imports.d.ts
+++ b/auto-imports.d.ts
@@ -59,6 +59,7 @@ declare global {
   const useAttrs: typeof import('vue')['useAttrs']
   const useCssModule: typeof import('vue')['useCssModule']
   const useCssVars: typeof import('vue')['useCssVars']
+  const useErrorStore: typeof import('./src/stores/error')['useErrorStore']
   const useLink: typeof import('vue-router')['useLink']
   const usePageStore: typeof import('./src/stores/page')['usePageStore']
   const useRoute: typeof import('vue-router')['useRoute']

--- a/components.d.ts
+++ b/components.d.ts
@@ -7,6 +7,7 @@ export {}
 /* prettier-ignore */
 declare module 'vue' {
   export interface GlobalComponents {
+    AppErrorPage: typeof import('./src/components/AppError/AppErrorPage.vue')['default']
     AuthLayout: typeof import('./src/components/Layout/main/AuthLayout.vue')['default']
     Avatar: typeof import('./src/components/ui/avatar/Avatar.vue')['default']
     AvatarFallback: typeof import('./src/components/ui/avatar/AvatarFallback.vue')['default']

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,10 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+const errorStore = useErrorStore()
+</script>
 <template>
   <AuthLayout>
-    <RouterView v-slot="{ Component, route }">
+    <AppErrorPage v-if="errorStore.activeError" />
+    <RouterView v-else v-slot="{ Component, route }">
       <Suspense v-if="Component" timeout="0">
         <Component :is="Component" :key="route.name" />
         <template #fallback>

--- a/src/components/AppError/AppErrorPage.vue
+++ b/src/components/AppError/AppErrorPage.vue
@@ -1,0 +1,45 @@
+<template>
+  <section class="error">
+    <div>
+      <iconify-icon icon="lucide:triangle-alert" class="error__icon" />
+      <h1 class="error__code">404</h1>
+      <p class="error__msg">Page not found</p>
+      <div class="error-footer">
+        <p class="error-footer__text">You'll find lots to explore on the home page.</p>
+        <RouterLink to="/">
+          <Button class="max-w-36"> Back to homepage </Button>
+        </RouterLink>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.error {
+  @apply mx-auto flex justify-center items-center flex-1 p-10 text-center -mt-20 min-h-[90vh];
+}
+
+.error__icon {
+  @apply text-7xl text-destructive;
+}
+
+.error__code {
+  @apply font-extrabold text-7xl text-secondary;
+}
+
+.error__msg {
+  @apply text-3xl font-extrabold text-primary;
+}
+
+.error-footer {
+  @apply flex flex-col items-center justify-center gap-5 mt-6 font-light;
+}
+
+.error-footer__text {
+  @apply text-lg text-muted-foreground;
+}
+
+p {
+  @apply my-2;
+}
+</style>

--- a/src/components/AppError/AppErrorPage.vue
+++ b/src/components/AppError/AppErrorPage.vue
@@ -1,3 +1,10 @@
+<script setup lang="ts">
+const router = useRouter()
+
+router.afterEach(() => {
+  useErrorStore().activeError = false
+})
+</script>
 <template>
   <section class="error">
     <div>

--- a/src/components/AppError/AppErrorPage.vue
+++ b/src/components/AppError/AppErrorPage.vue
@@ -1,16 +1,25 @@
 <script setup lang="ts">
 const router = useRouter()
 
+const errorStore = useErrorStore()
+const error = ref(errorStore.activeError)
+const message = ref('')
+const customCode = ref(0)
+if (error.value) {
+  message.value = error.value.message
+  customCode.value = error.value.customCode ?? 0
+}
+
 router.afterEach(() => {
-  useErrorStore().activeError = false
+  useErrorStore().activeError = null
 })
 </script>
 <template>
   <section class="error">
     <div>
       <iconify-icon icon="lucide:triangle-alert" class="error__icon" />
-      <h1 class="error__code">404</h1>
-      <p class="error__msg">Page not found</p>
+      <h1 class="error__code">{{ customCode }}</h1>
+      <p class="error__msg">{{ message }}</p>
       <div class="error-footer">
         <p class="error-footer__text">You'll find lots to explore on the home page.</p>
         <RouterLink to="/">

--- a/src/pages/[...catchall].vue
+++ b/src/pages/[...catchall].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-useErrorStore().setError()
+useErrorStore().setError({ error: 'Page not found', customCode: 404 })
 </script>
 
 <template>

--- a/src/pages/[...catchall].vue
+++ b/src/pages/[...catchall].vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
-import AppErrorPage from '@/components/AppError/AppErrorPage.vue'
+useErrorStore().setError()
 </script>
-<script setup lang="ts"></script>
 
 <template>
-  <AppErrorPage />
+  <div></div>
 </template>

--- a/src/pages/[...catchall].vue
+++ b/src/pages/[...catchall].vue
@@ -1,12 +1,8 @@
+<script setup lang="ts">
+import AppErrorPage from '@/components/AppError/AppErrorPage.vue'
+</script>
 <script setup lang="ts"></script>
-<template>
-  <div>
-    <h2>404 Not Found</h2>
-  </div>
-</template>
 
-<style scoped>
-h2 {
-  color: red;
-}
-</style>
+<template>
+  <AppErrorPage />
+</template>

--- a/src/stores/error.ts
+++ b/src/stores/error.ts
@@ -1,0 +1,12 @@
+export const useErrorStore = defineStore('error-store', () => {
+  const activeError = ref(false)
+
+  const setError = () => {
+    activeError.value = true
+  }
+
+  return {
+    activeError,
+    setError
+  }
+})

--- a/src/stores/error.ts
+++ b/src/stores/error.ts
@@ -1,8 +1,11 @@
-export const useErrorStore = defineStore('error-store', () => {
-  const activeError = ref(false)
+import type { CustomError } from '@/types/Error'
 
-  const setError = () => {
-    activeError.value = true
+export const useErrorStore = defineStore('error-store', () => {
+  const activeError = ref<null | CustomError>(null)
+
+  const setError = ({ error, customCode }: { error: string; customCode: number }) => {
+    activeError.value = new Error(error)
+    activeError.value.customCode = customCode
   }
 
   return {

--- a/src/types/Error.ts
+++ b/src/types/Error.ts
@@ -1,0 +1,3 @@
+export interface CustomError extends Error {
+  customCode?: number
+}


### PR DESCRIPTION
This pr initiates the strategy for displaying errors with useful messages for the user and the developer:
- Create a component to be used for displaying errors
- Use pinia to store a global error object which extends javascript's Error class
- In App.vue first check if there is an error before routing to the appropriate component - or the error component
- Set the error message and code to be displayed in the catchall route
- Use a navigation after hook to update the error store so the error page is not displayed when navigating away from it
