### PR TITLE
Extend error page

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,9 @@
 <script setup lang="ts">
 const errorStore = useErrorStore()
+
+onErrorCaptured((error) => {
+  errorStore.setError({ error })
+})
 </script>
 <template>
   <AuthLayout>

--- a/src/components/AppError/AppErrorPage.vue
+++ b/src/components/AppError/AppErrorPage.vue
@@ -5,9 +5,22 @@ const errorStore = useErrorStore()
 const error = ref(errorStore.activeError)
 const message = ref('')
 const customCode = ref(0)
-if (error.value) {
+const details = ref('')
+const code = ref('')
+const hint = ref('')
+const statusCode = ref(0)
+
+if (error.value && !('code' in error.value)) {
   message.value = error.value.message
   customCode.value = error.value.customCode ?? 0
+}
+
+if (error.value && 'code' in error.value) {
+  message.value = error.value.message
+  details.value = error.value.details
+  hint.value = error.value.hint
+  code.value = error.value.code
+  statusCode.value = error.value.statusCode ?? 0
 }
 
 router.afterEach(() => {
@@ -18,8 +31,11 @@ router.afterEach(() => {
   <section class="error">
     <div>
       <iconify-icon icon="lucide:triangle-alert" class="error__icon" />
-      <h1 class="error__code">{{ customCode }}</h1>
+      <h1 class="error__code">{{ customCode || code }}</h1>
+      <p class="error__code" v-if="statusCode">Status Code:{{ statusCode }}</p>
       <p class="error__msg">{{ message }}</p>
+      <p class="error__msg" v-if="hint">{{ hint }}</p>
+      <p class="error__msg" v-if="details">{{ details }}</p>
       <div class="error-footer">
         <p class="error-footer__text">You'll find lots to explore on the home page.</p>
         <RouterLink to="/">

--- a/src/pages/projects/[slug].vue
+++ b/src/pages/projects/[slug].vue
@@ -13,9 +13,9 @@ watch(
 )
 
 const getProject = async () => {
-  const { data, error } = await projectQuery(route.params.slug)
+  const { data, error, status } = await projectQuery(route.params.slug)
 
-  if (error) console.error(error)
+  if (error) useErrorStore().setError({ error, customCode: status })
 
   project.value = data
 }

--- a/src/pages/projects/index.vue
+++ b/src/pages/projects/index.vue
@@ -8,10 +8,10 @@ usePageStore().pageData.title = 'Projects'
 const projects = ref<Projects | null>(null)
 
 const getProjects = async () => {
-  const { data, error } = await projectsQuery
+  const { data, error, status } = await projectsQuery
 
   if (error) {
-    console.error(error)
+    useErrorStore().setError({ error, customCode: status })
   }
 
   projects.value = data

--- a/src/pages/tasks/[id].vue
+++ b/src/pages/tasks/[id].vue
@@ -13,9 +13,9 @@ watch(
 )
 
 const getTask = async () => {
-  const { data, error } = await taskQuery(route.params.id)
+  const { data, error, status } = await taskQuery(route.params.id)
 
-  if (error) console.error(error)
+  if (error) useErrorStore().setError({ error, customCode: status })
 
   task.value = data
 }

--- a/src/pages/tasks/index.vue
+++ b/src/pages/tasks/index.vue
@@ -8,8 +8,8 @@ usePageStore().pageData.title = 'My tasks'
 const tasks = ref<TasksWithProjects | null>(null)
 
 const getTasks = async () => {
-  const { data, error } = await tasksWithProjectsQuery
-  if (error) console.log(error)
+  const { data, error, status } = await tasksWithProjectsQuery
+  if (error) useErrorStore().setError({ error, customCode: status })
 
   tasks.value = data
 }

--- a/src/stores/error.ts
+++ b/src/stores/error.ts
@@ -8,17 +8,17 @@ export const useErrorStore = defineStore('error-store', () => {
     error,
     customCode
   }: {
-    error: string | PostgrestError
-    customCode: number
+    error: string | PostgrestError | Error
+    customCode?: number
   }) => {
-    if (typeof error === 'string') {
-      activeError.value = new Error(error)
-      activeError.value.customCode = customCode
+    if (typeof error === 'string' || error instanceof Error) {
+      activeError.value = typeof error === 'string' ? new Error(error) : error
+      activeError.value.customCode = customCode || 500
       return
     }
 
     activeError.value = error
-    activeError.value.statusCode = customCode
+    activeError.value.statusCode = customCode || 500
   }
 
   return {

--- a/src/stores/error.ts
+++ b/src/stores/error.ts
@@ -1,11 +1,24 @@
-import type { CustomError } from '@/types/Error'
+import type { CustomError, ExtendedPostgrestError } from '@/types/Error'
+import type { PostgrestError } from '@supabase/supabase-js'
 
 export const useErrorStore = defineStore('error-store', () => {
-  const activeError = ref<null | CustomError>(null)
+  const activeError = ref<null | CustomError | ExtendedPostgrestError>(null)
 
-  const setError = ({ error, customCode }: { error: string; customCode: number }) => {
-    activeError.value = new Error(error)
-    activeError.value.customCode = customCode
+  const setError = ({
+    error,
+    customCode
+  }: {
+    error: string | PostgrestError
+    customCode: number
+  }) => {
+    if (typeof error === 'string') {
+      activeError.value = new Error(error)
+      activeError.value.customCode = customCode
+      return
+    }
+
+    activeError.value = error
+    activeError.value.statusCode = customCode
   }
 
   return {

--- a/src/types/Error.ts
+++ b/src/types/Error.ts
@@ -1,3 +1,9 @@
+import type { PostgrestError } from '@supabase/supabase-js'
+
 export interface CustomError extends Error {
   customCode?: number
+}
+
+export interface ExtendedPostgrestError extends PostgrestError {
+  statusCode?: number
 }


### PR DESCRIPTION
Adjust the error handling to handle d/b errors and native javascript errors.
- Amend the Error type to include PostgrestError
- Extend the PostgrestError type to include a status code
- Add the postgrest error fields to the error template
- use vue's onErrorCaptured lifecycle hook to capture js errors
- Instead of console logging the error in the pages that use
supabse queries, pass the error details to the global error var in the store