### PR TITLE
Env specific error templates

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -7,6 +7,7 @@ export {}
 /* prettier-ignore */
 declare module 'vue' {
   export interface GlobalComponents {
+    AppErrorDevSection: typeof import('./src/components/AppError/AppErrorDevSection.vue')['default']
     AppErrorPage: typeof import('./src/components/AppError/AppErrorPage.vue')['default']
     AuthLayout: typeof import('./src/components/Layout/main/AuthLayout.vue')['default']
     Avatar: typeof import('./src/components/ui/avatar/Avatar.vue')['default']

--- a/components.d.ts
+++ b/components.d.ts
@@ -9,6 +9,7 @@ declare module 'vue' {
   export interface GlobalComponents {
     AppErrorDevSection: typeof import('./src/components/AppError/AppErrorDevSection.vue')['default']
     AppErrorPage: typeof import('./src/components/AppError/AppErrorPage.vue')['default']
+    AppErrorProdSection: typeof import('./src/components/AppError/AppErrorProdSection.vue')['default']
     AuthLayout: typeof import('./src/components/Layout/main/AuthLayout.vue')['default']
     Avatar: typeof import('./src/components/ui/avatar/Avatar.vue')['default']
     AvatarFallback: typeof import('./src/components/ui/avatar/AvatarFallback.vue')['default']

--- a/src/components/AppError/AppErrorDevSection.vue
+++ b/src/components/AppError/AppErrorDevSection.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+defineProps<{
+  message: string
+  customCode: number
+  code: string
+  statusCode: number
+  hint: string | null
+  details: string
+}>()
+</script>
+<template>
+  <div>
+    <iconify-icon icon="lucide:triangle-alert" class="error__icon" />
+    <h1 class="error__code">{{ customCode || code }}</h1>
+    <p class="error__code" v-if="statusCode">Status Code:{{ statusCode }}</p>
+    <p class="error__msg">{{ message }}</p>
+    <p v-if="hint">{{ hint }}</p>
+    <p v-if="details">{{ details }}</p>
+    <div class="error-footer">
+      <p class="error-footer__text">You'll find lots to explore on the home page.</p>
+      <RouterLink to="/">
+        <Button class="max-w-36"> Back to homepage </Button>
+      </RouterLink>
+    </div>
+  </div>
+</template>

--- a/src/components/AppError/AppErrorPage.vue
+++ b/src/components/AppError/AppErrorPage.vue
@@ -23,13 +23,17 @@ if (error.value && 'code' in error.value) {
   statusCode.value = error.value.statusCode ?? 0
 }
 
+const ErrorTemplate = import.meta.env.DEV
+  ? defineAsyncComponent(() => import('./AppErrorDevSection.vue'))
+  : defineAsyncComponent(() => import('./AppErrorProdSection.vue'))
+
 router.afterEach(() => {
-  useErrorStore().activeError = null
+  useErrorStore().clearError()
 })
 </script>
 <template>
   <section class="error">
-    <AppErrorDevSection
+    <ErrorTemplate
       :message
       :customCode
       :code

--- a/src/components/AppError/AppErrorPage.vue
+++ b/src/components/AppError/AppErrorPage.vue
@@ -29,7 +29,15 @@ router.afterEach(() => {
 </script>
 <template>
   <section class="error">
-    <AppErrorDevSection :message :customCode :code :status-code :hint :details />
+    <AppErrorDevSection
+      :message
+      :customCode
+      :code
+      :status-code
+      :hint
+      :details
+      :isCustomError="errorStore.isCustomError"
+    />
   </section>
 </template>
 

--- a/src/components/AppError/AppErrorPage.vue
+++ b/src/components/AppError/AppErrorPage.vue
@@ -29,20 +29,7 @@ router.afterEach(() => {
 </script>
 <template>
   <section class="error">
-    <div>
-      <iconify-icon icon="lucide:triangle-alert" class="error__icon" />
-      <h1 class="error__code">{{ customCode || code }}</h1>
-      <p class="error__code" v-if="statusCode">Status Code:{{ statusCode }}</p>
-      <p class="error__msg">{{ message }}</p>
-      <p class="error__msg" v-if="hint">{{ hint }}</p>
-      <p class="error__msg" v-if="details">{{ details }}</p>
-      <div class="error-footer">
-        <p class="error-footer__text">You'll find lots to explore on the home page.</p>
-        <RouterLink to="/">
-          <Button class="max-w-36"> Back to homepage </Button>
-        </RouterLink>
-      </div>
-    </div>
+    <AppErrorDevSection :message :customCode :code :status-code :hint :details />
   </section>
 </template>
 
@@ -51,27 +38,27 @@ router.afterEach(() => {
   @apply mx-auto flex justify-center items-center flex-1 p-10 text-center -mt-20 min-h-[90vh];
 }
 
-.error__icon {
+:deep(.error__icon) {
   @apply text-7xl text-destructive;
 }
 
-.error__code {
+:deep(.error__code) {
   @apply font-extrabold text-7xl text-secondary;
 }
 
-.error__msg {
+:deep(.error__msg) {
   @apply text-3xl font-extrabold text-primary;
 }
 
-.error-footer {
+:deep(.error-footer) {
   @apply flex flex-col items-center justify-center gap-5 mt-6 font-light;
 }
 
-.error-footer__text {
+:deep(.error-footer__text) {
   @apply text-lg text-muted-foreground;
 }
 
-p {
+:deep(p) {
   @apply my-2;
 }
 </style>

--- a/src/components/AppError/AppErrorProdSection.vue
+++ b/src/components/AppError/AppErrorProdSection.vue
@@ -2,10 +2,7 @@
 const props = defineProps<{
   message: string
   customCode: number
-  code: string
   statusCode: number
-  hint: string | null
-  details: string
   isCustomError: boolean
 }>()
 

--- a/src/components/AppError/AppErrorProdSection.vue
+++ b/src/components/AppError/AppErrorProdSection.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+const props = defineProps<{
+  message: string
+  customCode: number
+  code: string
+  statusCode: number
+  hint: string | null
+  details: string
+  isCustomError: boolean
+}>()
+
+const error = ref({
+  code: 500,
+  msg: 'Oops, something went wrong'
+})
+
+if (props.isCustomError) {
+  error.value.code = props.customCode
+  error.value.msg = props.message
+}
+
+if (props.statusCode === 406) {
+  error.value.code = 404
+  error.value.msg = "Sorry, we couldn't find this page"
+}
+</script>
+<template>
+  <div>
+    <iconify-icon icon="lucide:triangle-alert" class="error__icon" />
+    <h1 class="error__code">{{ error.code }}</h1>
+    <p class="error__msg">{{ error.msg }}</p>
+    <div class="error-footer">
+      <p class="error-footer__text">You'll find lots to explore on the home page.</p>
+      <RouterLink to="/">
+        <Button class="max-w-36"> Back to homepage </Button>
+      </RouterLink>
+    </div>
+  </div>
+</template>

--- a/src/stores/error.ts
+++ b/src/stores/error.ts
@@ -3,7 +3,7 @@ import type { PostgrestError } from '@supabase/supabase-js'
 
 export const useErrorStore = defineStore('error-store', () => {
   const activeError = ref<null | CustomError | ExtendedPostgrestError>(null)
-
+  const isCustomError = ref(false)
   const setError = ({
     error,
     customCode
@@ -11,6 +11,8 @@ export const useErrorStore = defineStore('error-store', () => {
     error: string | PostgrestError | Error
     customCode?: number
   }) => {
+    if (typeof error === 'string') isCustomError.value = true
+
     if (typeof error === 'string' || error instanceof Error) {
       activeError.value = typeof error === 'string' ? new Error(error) : error
       activeError.value.customCode = customCode || 500
@@ -23,6 +25,7 @@ export const useErrorStore = defineStore('error-store', () => {
 
   return {
     activeError,
-    setError
+    setError,
+    isCustomError
   }
 })

--- a/src/stores/error.ts
+++ b/src/stores/error.ts
@@ -23,9 +23,15 @@ export const useErrorStore = defineStore('error-store', () => {
     activeError.value.statusCode = customCode || 500
   }
 
+  const clearError = () => {
+    activeError.value = null
+    isCustomError.value = false
+  }
+
   return {
     activeError,
     setError,
-    isCustomError
+    isCustomError,
+    clearError
   }
 })


### PR DESCRIPTION
## Display different error information for devs and end users.

### Summary
By dynamically importing the appropriate error component, we optimize performance and ensure that developers see detailed error messages during development while end-users get simplified, user-friendly error pages in production. This approach leverages environment variables like import.meta.env.DEV to determine which component to load, providing flexibility and efficiency in handling errors across different environments.

### Specifics
- Create 2  error components - one for development environment and one for production environment
- Use vue's `defineAsyncComponent` to render the appropriate component
- Use props to pass the error details to the new component
- Leverage vue's pseudo class `:deep` to enable the styles from the
parent component to be used in the child component
- Create a flag in the global error store to define if an error is a custom error which enables displaying the error code. We need this because the error object is of different type and its code is called different terms if it is a js error or a postgrest error. We want to display full error details in the development error component and convert it to something user appropriate in the production error component.
- Determine which template to render using the env data from the meta
object
- Create a clear error function to clear all the error specific rendering
variables in the global store