### PR TITLE
Managing the user session

### DIFF
--- a/auto-imports.d.ts
+++ b/auto-imports.d.ts
@@ -57,6 +57,7 @@ declare global {
   const triggerRef: typeof import('vue')['triggerRef']
   const unref: typeof import('vue')['unref']
   const useAttrs: typeof import('vue')['useAttrs']
+  const useAuthStore: typeof import('./src/stores/auth')['useAuthStore']
   const useCssModule: typeof import('vue')['useCssModule']
   const useCssVars: typeof import('vue')['useCssVars']
   const useErrorStore: typeof import('./src/stores/error')['useErrorStore']

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,8 +1,16 @@
 <script setup lang="ts">
+import { supabase } from './lib/supabaseClient'
+
 const errorStore = useErrorStore()
+const authStore = useAuthStore()
 
 onErrorCaptured((error) => {
   errorStore.setError({ error })
+})
+
+onMounted(async () => {
+  const { data } = await supabase.auth.getSession()
+  if (data.session?.user) await authStore.setAuth(data.session)
 })
 </script>
 <template>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,16 +1,8 @@
 <script setup lang="ts">
-import { supabase } from './lib/supabaseClient'
-
 const errorStore = useErrorStore()
-const authStore = useAuthStore()
 
 onErrorCaptured((error) => {
   errorStore.setError({ error })
-})
-
-onMounted(async () => {
-  const { data } = await supabase.auth.getSession()
-  if (data.session?.user) await authStore.setAuth(data.session)
 })
 </script>
 <template>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -6,4 +6,9 @@ const router = createRouter({
   routes
 })
 
+router.beforeEach(async () => {
+  const { getSession } = useAuthStore()
+  await getSession()
+})
+
 export default router

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -1,0 +1,12 @@
+import type { User } from '@supabase/supabase-js'
+import type { Tables } from 'database/types'
+
+export const useAuthStore = defineStore('auth-store', () => {
+  const user = ref<null | User>(null)
+  const profile = ref<null | Tables<'profiles'>>(null)
+
+  return {
+    user,
+    profile
+  }
+})

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -1,3 +1,4 @@
+import { profileQuery } from '@/utils/supaQueries'
 import type { Session, User } from '@supabase/supabase-js'
 import type { Tables } from 'database/types'
 
@@ -5,12 +6,25 @@ export const useAuthStore = defineStore('auth-store', () => {
   const user = ref<null | User>(null)
   const profile = ref<null | Tables<'profiles'>>(null)
 
-  const setAuth = (userSession: null | Session = null) => {
+  const setProfile = async () => {
+    if (!user.value) {
+      profile.value = null
+      return
+    }
+
+    if (!profile.value || profile.value.id !== user.value.id) {
+      const { data } = await profileQuery(user.value.id)
+      profile.value = data || null
+    }
+  }
+
+  const setAuth = async (userSession: null | Session = null) => {
     if (!userSession) {
       user.value = null
       return
     }
     user.value = userSession.user
+    await setProfile()
   }
 
   return {

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -1,3 +1,4 @@
+import { supabase } from '@/lib/supabaseClient'
 import { profileQuery } from '@/utils/supaQueries'
 import type { Session, User } from '@supabase/supabase-js'
 import type { Tables } from 'database/types'
@@ -27,9 +28,15 @@ export const useAuthStore = defineStore('auth-store', () => {
     await setProfile()
   }
 
+  const getSession = async () => {
+    const { data } = await supabase.auth.getSession()
+    if (data.session?.user) await setAuth(data.session)
+  }
+
   return {
     user,
     profile,
-    setAuth
+    setAuth,
+    getSession
   }
 })

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -1,12 +1,21 @@
-import type { User } from '@supabase/supabase-js'
+import type { Session, User } from '@supabase/supabase-js'
 import type { Tables } from 'database/types'
 
 export const useAuthStore = defineStore('auth-store', () => {
   const user = ref<null | User>(null)
   const profile = ref<null | Tables<'profiles'>>(null)
 
+  const setAuth = (userSession: null | Session = null) => {
+    if (!userSession) {
+      user.value = null
+      return
+    }
+    user.value = userSession.user
+  }
+
   return {
     user,
-    profile
+    profile,
+    setAuth
   }
 })

--- a/src/stores/error.ts
+++ b/src/stores/error.ts
@@ -35,3 +35,7 @@ export const useErrorStore = defineStore('error-store', () => {
     clearError
   }
 })
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useErrorStore, import.meta.hot))
+}

--- a/src/utils/supaAuth.ts
+++ b/src/utils/supaAuth.ts
@@ -1,6 +1,8 @@
 import { supabase } from '@/lib/supabaseClient'
 import type { LoginForm, RegisterForm } from '@/types/AuthForm'
 
+const authStore = useAuthStore()
+
 export const register = async (formData: RegisterForm) => {
   const { error, data } = await supabase.auth.signUp({
     email: formData.email,
@@ -17,16 +19,19 @@ export const register = async (formData: RegisterForm) => {
     })
     if (error) return console.log('Profiles insert err: ', error)
   }
+
+  authStore.setAuth(data.session)
   return true
 }
 
 export const signIn = async (formData: LoginForm) => {
-  const { error } = await supabase.auth.signInWithPassword({
+  const { data, error } = await supabase.auth.signInWithPassword({
     email: formData.email,
     password: formData.password
   })
 
   if (error) return console.error('Auth login err: ', error)
 
+  authStore.setAuth(data.session)
   return true
 }

--- a/src/utils/supaAuth.ts
+++ b/src/utils/supaAuth.ts
@@ -20,7 +20,7 @@ export const register = async (formData: RegisterForm) => {
     if (error) return console.log('Profiles insert err: ', error)
   }
 
-  authStore.setAuth(data.session)
+  await authStore.setAuth(data.session)
   return true
 }
 
@@ -32,6 +32,10 @@ export const signIn = async (formData: LoginForm) => {
 
   if (error) return console.error('Auth login err: ', error)
 
-  authStore.setAuth(data.session)
+  await authStore.setAuth(data.session)
   return true
+}
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useAuthStore, import.meta.hot))
 }

--- a/src/utils/supaQueries.ts
+++ b/src/utils/supaQueries.ts
@@ -47,3 +47,7 @@ export const taskQuery = (id: string) => {
     .single()
 }
 export type Task = QueryData<ReturnType<typeof taskQuery>>
+
+export const profileQuery = (id: string) => {
+  return supabase.from('profiles').select().eq('id', id).single()
+}


### PR DESCRIPTION
## Enable a user to stay signed in
### Summary
In order for a user to stay signed in even when they navigate away from the site requires the session to be checked prior to routing to every page.
### Specifics
- Store the user and profile in a global store to be able to access throughout the app
- After logging in or registering, store the session data in the global auth store and fetch the associated profile data from supabase
- In the router index, use a before hook to verify the session
---

#### Complete the following before creating a PR
- [x] Replace **Title** with a short meaningful. Mandatory
- [x] **Summary** - Mandatory.Provide a paragraph that summarises the feature or reason for the pr
- [x] **Specifics** - Optional. List the details of the code changes
