### PR TITLE
Sign Out

### DIFF
--- a/src/components/layout/Sidebar.vue
+++ b/src/components/layout/Sidebar.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+const router = useRouter()
+
 const links = [
   {
     title: 'Dashboard',
@@ -34,9 +36,11 @@ const accountLinks = [
   }
 ]
 
-const executeAction = (linkTitle: string) => {
+const executeAction = async (linkTitle: string) => {
   if (linkTitle === 'Sign out') {
-    console.log('sign out clicked')
+    const { signout } = await import('@/utils/supaAuth')
+    const isSignedOut = await signout()
+    if (isSignedOut) router.push('/')
   }
 }
 </script>

--- a/src/components/layout/Sidebar.vue
+++ b/src/components/layout/Sidebar.vue
@@ -30,8 +30,7 @@ const accountLinks = [
   },
   {
     title: 'Sign out',
-    to: '/signout',
-    icon: 'lucide:badge-check'
+    icon: 'lucide:log-out'
   }
 ]
 </script>

--- a/src/components/layout/Sidebar.vue
+++ b/src/components/layout/Sidebar.vue
@@ -33,6 +33,12 @@ const accountLinks = [
     icon: 'lucide:log-out'
   }
 ]
+
+const executeAction = (linkTitle: string) => {
+  if (linkTitle === 'Sign out') {
+    console.log('sign out clicked')
+  }
+}
 </script>
 
 <template>
@@ -55,7 +61,7 @@ const accountLinks = [
       </div>
 
       <div class="border-y text-center bg-background py-3">
-        <SidebarLinks :links="accountLinks" />
+        <SidebarLinks :links="accountLinks" @actionClicked="executeAction" />
       </div>
     </nav>
   </aside>

--- a/src/components/layout/SidebarLinks.vue
+++ b/src/components/layout/SidebarLinks.vue
@@ -8,6 +8,14 @@ interface linkProp {
 defineProps<{
   links: linkProp[]
 }>()
+
+const emits = defineEmits<{
+  actionClicked: [string]
+}>()
+
+const emitActionClicked = (linkTitle: string) => {
+  emits('actionClicked', linkTitle)
+}
 </script>
 
 <template>
@@ -21,7 +29,7 @@ defineProps<{
       <iconify-icon :icon="link.icon"></iconify-icon>
       <span class="hidden lg:block text-nowrap">{{ link.title }}</span>
     </RouterLink>
-    <div v-else class="nav-link cursor-pointer">
+    <div v-else class="nav-link cursor-pointer" @click="emitActionClicked(link.title)">
       <iconify-icon :icon="link.icon"></iconify-icon>
       <span class="hidden lg:block text-nowrap">{{ link.title }}</span>
     </div>

--- a/src/components/layout/SidebarLinks.vue
+++ b/src/components/layout/SidebarLinks.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 interface linkProp {
   title: string
-  to: string
+  to?: string
   icon: string
 }
 
@@ -11,14 +11,25 @@ defineProps<{
 </script>
 
 <template>
-  <RouterLink
-    exactActiveClass="text-primary bg-muted"
-    v-for="link in links"
-    :key="link.title"
-    :to="link.to"
-    class="flex items-center gap-3 px-4 py-2 mx-2 transition-colors rounded-lg hover:text-primary justify-center lg:justify-normal text-muted-foreground"
-  >
-    <iconify-icon :icon="link.icon"></iconify-icon>
-    <span class="hidden lg:block text-nowrap">{{ link.title }}</span>
-  </RouterLink>
+  <template v-for="link in links" :key="link.title">
+    <RouterLink
+      v-if="link.to"
+      exactActiveClass="text-primary bg-muted"
+      :to="link.to"
+      class="nav-link"
+    >
+      <iconify-icon :icon="link.icon"></iconify-icon>
+      <span class="hidden lg:block text-nowrap">{{ link.title }}</span>
+    </RouterLink>
+    <div v-else class="nav-link cursor-pointer">
+      <iconify-icon :icon="link.icon"></iconify-icon>
+      <span class="hidden lg:block text-nowrap">{{ link.title }}</span>
+    </div>
+  </template>
 </template>
+
+<style scoped>
+.nav-link {
+  @apply flex items-center gap-3 px-4 py-2 mx-2 transition-colors rounded-lg hover:text-primary justify-center lg:justify-normal text-muted-foreground;
+}
+</style>

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -22,6 +22,7 @@ export const useAuthStore = defineStore('auth-store', () => {
   const setAuth = async (userSession: null | Session = null) => {
     if (!userSession) {
       user.value = null
+      profile.value = null
       return
     }
     user.value = userSession.user

--- a/src/utils/supaAuth.ts
+++ b/src/utils/supaAuth.ts
@@ -36,6 +36,15 @@ export const signIn = async (formData: LoginForm) => {
   return true
 }
 
+export const signout = async () => {
+  const { error } = await supabase.auth.signOut()
+
+  if (error) return console.error('Signout err: ', error)
+
+  await authStore.setAuth()
+  return true
+}
+
 if (import.meta.hot) {
   import.meta.hot.accept(acceptHMRUpdate(useAuthStore, import.meta.hot))
 }


### PR DESCRIPTION
## Sign Out
### Summary
Enable the user to sign out. Currently nothing happens when the signout link in the sidebar is clicked. This pr handles that action by destroying the session token and redirects the user to the home page.
### Specifics
- Update the signout navigation item - change it from a router link to a clickable html element in order
to trigger a function to destroy the user session and not to trigger
navigating to another page
- Emit an action from the signout link to its parent component
- In the parent, listen for the action being emitted and create a function to process accordingly
- create a signout function in the auth store to:
1 use supabase's signOut method to remove the session tokens
2 set the profile and user variables in global store to null
3 if all goes well, redirect to the home page

**NOTE** - Since the sidebar is rendered outside routerview, pinia may not be available. To overcome this challenge, we can use dynamic imports to access the signout function.

#### Complete the following before creating a PR
- [x] Replace **Title** with something short and meaningful.
- [x] **Summary** - Provide a paragraph that summarises the feature or reason for the pr. **Mandatory**
- [x] **Specifics** - List the details of the code changes. **Optional**
