### PR TITLE
Protect routes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,6 +4,10 @@ const errorStore = useErrorStore()
 onErrorCaptured((error) => {
   errorStore.setError({ error })
 })
+
+onMounted(() => {
+  useAuthStore().trackAuthChanges()
+})
 </script>
 <template>
   <AuthLayout>

--- a/src/components/layout/Sidebar.vue
+++ b/src/components/layout/Sidebar.vue
@@ -40,7 +40,8 @@ const executeAction = async (linkTitle: string) => {
   if (linkTitle === 'Sign out') {
     const { signout } = await import('@/utils/supaAuth')
     const isSignedOut = await signout()
-    if (isSignedOut) router.push('/')
+
+    if (isSignedOut) router.push('/login')
   }
 }
 </script>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -6,9 +6,4 @@ const router = createRouter({
   routes
 })
 
-router.beforeEach(async () => {
-  const { getSession } = useAuthStore()
-  await getSession()
-})
-
 export default router

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -6,12 +6,21 @@ const router = createRouter({
   routes
 })
 
-router.beforeEach((to, from) => {
-  const { user } = storeToRefs(useAuthStore())
+router.beforeEach(async (to, from) => {
+  const authStore = useAuthStore()
+  await authStore.getSession()
 
-  if (!user.value && !['/login', '/register'].includes(to.path)) {
+  const isAuthPage = ['/login', '/register'].includes(to.path)
+
+  if (!authStore.user && !isAuthPage) {
     return {
       name: '/login'
+    }
+  }
+
+  if (authStore.user && isAuthPage) {
+    return {
+      name: '/'
     }
   }
 })

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -6,4 +6,14 @@ const router = createRouter({
   routes
 })
 
+router.beforeEach((to, from) => {
+  const { user } = storeToRefs(useAuthStore())
+
+  if (!user.value && !['/login', '/register'].includes(to.path)) {
+    return {
+      name: '/login'
+    }
+  }
+})
+
 export default router

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -6,6 +6,7 @@ import type { Tables } from 'database/types'
 export const useAuthStore = defineStore('auth-store', () => {
   const user = ref<null | User>(null)
   const profile = ref<null | Tables<'profiles'>>(null)
+  const isTrackingChanges = ref(false)
 
   const setProfile = async () => {
     if (!user.value) {
@@ -34,10 +35,22 @@ export const useAuthStore = defineStore('auth-store', () => {
     if (data.session?.user) await setAuth(data.session)
   }
 
+  const trackAuthChanges = async () => {
+    if (isTrackingChanges.value) return
+
+    isTrackingChanges.value = true
+    supabase.auth.onAuthStateChange((event, session) => {
+      setTimeout(async () => {
+        await setAuth(session)
+      }, 0)
+    })
+  }
+
   return {
     user,
     profile,
     setAuth,
-    getSession
+    getSession,
+    trackAuthChanges
   }
 })

--- a/src/utils/supaAuth.ts
+++ b/src/utils/supaAuth.ts
@@ -1,8 +1,6 @@
 import { supabase } from '@/lib/supabaseClient'
 import type { LoginForm, RegisterForm } from '@/types/AuthForm'
 
-const authStore = useAuthStore()
-
 export const register = async (formData: RegisterForm) => {
   const { error, data } = await supabase.auth.signUp({
     email: formData.email,
@@ -19,20 +17,16 @@ export const register = async (formData: RegisterForm) => {
     })
     if (error) return console.log('Profiles insert err: ', error)
   }
-
-  await authStore.setAuth(data.session)
   return true
 }
 
 export const signIn = async (formData: LoginForm) => {
-  const { data, error } = await supabase.auth.signInWithPassword({
+  const { error } = await supabase.auth.signInWithPassword({
     email: formData.email,
     password: formData.password
   })
 
   if (error) return console.error('Auth login err: ', error)
-
-  await authStore.setAuth(data.session)
   return true
 }
 
@@ -40,8 +34,6 @@ export const signout = async () => {
   const { error } = await supabase.auth.signOut()
 
   if (error) return console.error('Signout err: ', error)
-
-  await authStore.setAuth()
   return true
 }
 


### PR DESCRIPTION
## Ensure a user is signed in to be able to view most of the pages
### Summary
A user must be signed in to access the projects and tasks page and other facilities on the site.
### Specifics
1. Track authentication events such as signing in and out:
   - Supabase enables your app to listen to authentication events via its `onAuthStateChange` hook.
   - Implement this hook in the app's onMounted hook to trigger an
update to the auth store whenever there's a change in the session.
2. Protect the routes
   - use a before hook in the router to check if a user is signed in, otherwise redirect to the login page
   - exclude the login and register pages from the check to avoid
triggering an infinite loop
3. Redirect to the login page on signing out
4. Ensure the global auth store is updated before triggering navigation
---

#### Complete the following before creating a PR
- [x] Replace **Title** with something short and meaningful.
- [x] **Summary** - Provide a paragraph that summarises the feature or reason for the pr. **Mandatory**
- [x] **Specifics** - List the details of the code changes. **Optional**
